### PR TITLE
Silence deprecation warning about missing return type

### DIFF
--- a/src/Exception/MultipleExceptions.php
+++ b/src/Exception/MultipleExceptions.php
@@ -40,6 +40,7 @@ class MultipleExceptions extends Exception implements \IteratorAggregate
      * @return Traversable An instance of an object implementing <b>Iterator</b> or
      * <b>Traversable</b>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->exceptions);

--- a/src/Implementation/Record.php
+++ b/src/Implementation/Record.php
@@ -49,9 +49,9 @@ class Record implements RecordInterface
     /**
      * @param Header $header
      * @param \DOMDocument $metadata
-     * @param \DOMDocument $about
+     * @param \DOMDocument|null $about
      */
-    public function __construct(Header $header, \DOMDocument $metadata, \DOMDocument $about = null)
+    public function __construct(Header $header, \DOMDocument $metadata, ?\DOMDocument $about = null)
     {
         $this->about = $about;
         $this->header = $header;

--- a/src/Interfaces/Repository.php
+++ b/src/Interfaces/Repository.php
@@ -28,7 +28,7 @@ interface Repository
      * @return string the base URL of the repository
      */
     public function getBaseUrl();
-    
+
     /**
      * @return string
      * the finest harvesting granularity supported by the repository. The legitimate values are
@@ -62,12 +62,12 @@ interface Repository
     /**
      * @param string $metadataFormat metadata format of the records to be fetch or null if only headers are fetched
      * (listIdentifiers)
-     * @param \DateTime $from
-     * @param \DateTime $until
+     * @param \DateTime|null $from
+     * @param \DateTime|null $until
      * @param string $set name of the set containing this record
      * @return RecordList
      */
-    public function listRecords($metadataFormat = null, \DateTime $from = null, \DateTime $until = null, $set = null);
+    public function listRecords($metadataFormat = null, ?\DateTime $from = null, ?\DateTime $until = null, $set = null);
 
     /**
      * @param string $token
@@ -76,7 +76,7 @@ interface Repository
     public function listRecordsByToken($token);
 
     /**
-     * @param string $identifier
+     * @param string|null $identifier
      * @return MetadataFormatType[]
      */
     public function listMetadataFormats($identifier = null);

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -92,7 +92,7 @@ class Provider
     private $params = [];
 
     /**
-     * @var ServerRequestInterface
+     * @var ServerRequestInterface|null
      */
     private $request;
 
@@ -103,9 +103,9 @@ class Provider
 
     /**
      * @param Repository $repository
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface $request|null
      */
-    public function __construct(Repository $repository, ServerRequestInterface $request = null)
+    public function __construct(Repository $repository, ?ServerRequestInterface $request = null)
     {
         $this->repository = $repository;
 


### PR DESCRIPTION
(should be MultipleExceptions::getIterator(): \Traversable)